### PR TITLE
[BUG] Adjusted workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,9 +3,11 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: daily
+      interval: "weekly"
+    target-branch: development
 
   - package-ecosystem: npm
     directory: /
     schedule:
-      interval: daily
+      interval: "weekly"
+    target-branch: development

--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -6,13 +6,10 @@
 name: Check dist/
 
 on:
-  push:
+  pull_request:
     branches:
       - main
       - development
-    paths-ignore:
-      - '**.md'
-  pull_request:
     paths-ignore:
       - '**.md'
   workflow_dispatch:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -12,8 +12,6 @@
 name: "CodeQL"
 
 on:
-  push:
-    branches: [ main, development ]
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ main, development ]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,6 @@
 name: 'build-test'
 on: # rebuild any PRs and main branch changes
   pull_request:
-  push:
     branches:
       - main
       - development


### PR DESCRIPTION
## 1) Description

Updated the triggers of the workflows to not run on pushes.
Updated the Dependabot schedule from daily to weekly. 

This change is quite important as a bad run prevents #50 to be merged.

## 2) Technical choice

- The action is only built to be run on PR there is no sense to test it on pushes. At least for now.
- Running the code QL analysis on each push is a waste of resources, once on PR and on cron schedule is enough as all meaningful pushes were PR and thus analyzed. 
- Updating dependencies on a weekly is enough. I mean, we don't even do releases this often. 

## 3) Checks

- [X] My code follows the contributing guidelines
- [X] I have read the code of conduct
- [X] I have performed a self-review of my code
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes